### PR TITLE
Remove IPFS stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ NFT_MODULE_URL=http://localhost:3000
 KODADOT_URL=https://kodadot.xyz/ahk 
 #Subscan URL
 SUBSCAN_URL=https://assethub-kusama.subscan.io
-#IPFS username
-IPFS_USERNAME=ipfs
-#IPFS password
-IPFS_PASSWORD=password
 ```
 
 ## migrations

--- a/src/common/config/app-config.ts
+++ b/src/common/config/app-config.ts
@@ -10,7 +10,4 @@ export interface AppConfig {
   NFT_MODULE_URL: string;
   KODADOT_URL: string;
   SUBSCAN_URL: string;
-  IPFS_USERNAME: string;
-  IPFS_PASSWORD: string;
-  IPFS_URL: string;
 }


### PR DESCRIPTION
At the end, we exposed the /ipfs endpoint of our IPFS Node, so we are easily able to retrieve data without authorization. Thus  it can be removed.