### PR TITLE
Added global error handling

### DIFF
--- a/src/all-exceptions.filter.ts
+++ b/src/all-exceptions.filter.ts
@@ -1,0 +1,31 @@
+import {ExceptionFilter, Catch, ArgumentsHost, HttpException, Logger } from '@nestjs/common';
+import { Response } from 'express';
+
+@Catch()
+export class AllExceptionsFilter implements ExceptionFilter {
+
+  private logger = new Logger(AllExceptionsFilter.name)
+
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    if (exception instanceof HttpException) {
+      // Handle HTTP exceptions (e.g., BadRequestException, NotFoundException)
+      const status = exception.getStatus();
+      const message = exception.getResponse();
+      response.status(status).json({
+        statusCode: status,
+        message,
+      });
+    } else {
+      // Handle system errors and unexpected exceptions
+      this.logger.error('Unhandled Exception:', exception);
+
+      response.status(500).json({
+        statusCode: 500,
+        message: 'Internal server error',
+      });
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe } from '@nestjs/common';
+import { Logger, ValidationPipe } from '@nestjs/common';
 import { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
 import { Request as ExpressRequest } from 'express';
 import * as cookieParser from 'cookie-parser';
@@ -7,9 +7,25 @@ import { AppModule } from './app.module';
 import { AppConfigService } from '@modules/config';
 import { isLocalhostOrigin } from '@common/helpers';
 import { useContainer } from 'class-validator';
+import { AllExceptionsFilter } from './all-exceptions.filter';
 
 async function bootstrap() {
+  const logger = new Logger('main')
+
   const app = await NestFactory.create(AppModule);
+
+  // global error handler for errors in requests
+  app.useGlobalFilters(new AllExceptionsFilter());
+
+  // handle all other uncaught errors by logging
+  process.on('uncaughtException', (err) => {
+    logger.error('Uncaught Exception:', err);
+  });
+
+  process.on('unhandledRejection', (reason, promise) => {
+    logger.error('Unhandled Rejection:', reason);
+  });
+
   const config = app.get(AppConfigService);
   app.enableCors((req: ExpressRequest, callback) => {
     const opt: CorsOptions = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ async function bootstrap() {
     logger.error('Uncaught Exception:', err);
   });
 
-  process.on('unhandledRejection', (reason, promise) => {
+  process.on('unhandledRejection', (reason) => {
     logger.error('Unhandled Rejection:', reason);
   });
 

--- a/src/modules/main/contracts/public/mapper.ts
+++ b/src/modules/main/contracts/public/mapper.ts
@@ -128,11 +128,11 @@ export function createExhibitionDto(exhibition: Exhibition): ExhibitionDto {
     fromDate: exhibition.fromDate?.toISOString() ?? null,
     toDate: exhibition.toDate?.toISOString() ?? null,
     curator: exhibition.curator,
-    gallery: exhibition.gallery ? {
+    gallery: exhibition.gallery != null ? {
       name: exhibition.gallery.name,
       slug: exhibition.gallery.slug,
     } : null,
-    artwork: artwork ? {
+    artwork: artwork != null ? {
       name: artwork.name,
       slug: artwork.slug,
     } : null,


### PR DESCRIPTION
For each request all unhandled errors are converted to HTTP 500 response. Unhandled errors outside of requests are logged. This should prevent crashing (and subsequent restarting) of the server.